### PR TITLE
Assert three config-drift failures that have no symptom

### DIFF
--- a/public/_redirects
+++ b/public/_redirects
@@ -11,3 +11,16 @@
 # published at the old path, so the old path has to keep resolving — this file is
 # the whole reason a restructure does not have to break existing links.
 /guides/diagrams-and-code  /reference/code-and-diagrams  301
+
+# Sitemap name guessing. Crawlers ask for names this site does not use:
+# /sitemap_index.xml is the convention of the largest WordPress SEO plugins, so
+# it is the name a bot guesses before reading robots.txt — which does name the
+# real one, on its last line. Answering the guess costs one 301; the alternative
+# is restructuring a 22-URL sitemap around an index it has no need for.
+#
+# Deliberately short. Only the two spellings that a crawler has actually been
+# observed requesting on a sibling site are here — a longer list of plausible
+# names would be guesses about guesses, and every unused rule is a line that
+# outlives the reason it was added.
+/sitemap_index.xml  /sitemap.xml  301
+/sitemap-index.xml  /sitemap.xml  301

--- a/public/_redirects
+++ b/public/_redirects
@@ -16,7 +16,7 @@
 # /sitemap_index.xml is the convention of the largest WordPress SEO plugins, so
 # it is the name a bot guesses before reading robots.txt — which does name the
 # real one, on its last line. Answering the guess costs one 301; the alternative
-# is restructuring a 22-URL sitemap around an index it has no need for.
+# is restructuring a sitemap this small around an index it has no need for.
 #
 # Deliberately short. Only the two spellings that a crawler has actually been
 # observed requesting on a sibling site are here — a longer list of plausible

--- a/test/agents.test.mjs
+++ b/test/agents.test.mjs
@@ -601,3 +601,77 @@ describe('WebMCP bridge', () => {
     assert.deepEqual(await readRpcResponse(asStream), payload);
   });
 });
+
+/**
+ * The two files that have to agree about semantic retrieval.
+ *
+ * `agents.retrieval` and `agents.aiSearchInstance` live in src/docs.config.ts;
+ * the `AI_SEARCH` binding and its `instance_name` live in wrangler.jsonc. Both
+ * files already say in prose that they must match — and nothing checked it,
+ * which is the whole problem, because this particular disagreement has no
+ * symptom.
+ *
+ * A missing or misnamed binding does not fail the upload, does not 500, and does
+ * not empty the results: `retrieve()` catches it and serves the lexical index
+ * instead, deliberately, so that a misconfiguration degrades rather than breaks.
+ * That fallback is right. What it also does is make the two states
+ * indistinguishable from the outside — a site whose semantic index was never
+ * bound answers every search, plausibly, forever, with the floor implementation.
+ * The `search-timing` log names the backend on every request, so the evidence
+ * exists, but only for someone already looking; nothing brings them to look.
+ *
+ * So the check belongs here, before a deploy, where the disagreement is still
+ * two strings in two files rather than a quality regression nobody attributes.
+ *
+ * Asserted in one direction only. An `AI_SEARCH` binding left in place while
+ * `retrieval` is 'lexical' is a dead binding and probably an oversight too, but
+ * it costs nothing at runtime and a fork switching to the floor implementation
+ * should not have its CI fail over a line it has no reason to touch.
+ */
+describe('retrieval configuration', () => {
+  /* The `agents` object alone: `enabled` and `retrieval` are common enough words
+     that a regex over the whole file would eventually match something else. */
+  const configSource = readFileSync(path.join(ROOT, 'src', 'docs.config.ts'), 'utf8');
+  /* Terminated on a line-initial `}` rather than on `};`, because this object
+     closes with `} as const;` and matching the punctuation instead of the shape
+     is how a reader of this file silently gets an empty string. */
+  const agentsBlock = configSource.match(/^export const agents = \{$([\s\S]*?)^\}/m)?.[1] ?? '';
+  const agentsEnabled = /^\s*enabled:\s*true\b/m.test(agentsBlock);
+  const retrieval = agentsBlock.match(/^\s*retrieval:\s*'([^']+)'/m)?.[1];
+  const instance = agentsBlock.match(/^\s*aiSearchInstance:\s*'([^']*)'/m)?.[1];
+
+  const wranglerSource = readFileSync(path.join(ROOT, 'wrangler.jsonc'), 'utf8');
+  /* Read field by field rather than by parsing the file: wrangler.jsonc carries
+     comments and JSON.parse would need them stripped, and a stripper is more
+     code with more ways to be wrong than the two fields actually being read. */
+  const binding = wranglerSource.match(
+    /"binding":\s*"AI_SEARCH"[^}]*"instance_name":\s*"([^"]*)"/,
+  )?.[1];
+
+  test('docs.config.ts names a retrieval backend this suite knows', () => {
+    assert.ok(
+      retrieval === 'lexical' || retrieval === 'ai-search',
+      `agents.retrieval reads ${retrieval ?? 'as unset'} — the assertions below cannot judge it`,
+    );
+  });
+
+  test('an ai-search deployment declares the binding it retrieves through', t => {
+    if (!agentsEnabled || retrieval !== 'ai-search') {
+      t.skip(`retrieval is '${retrieval}'${agentsEnabled ? '' : ' and agents are off'}`);
+      return;
+    }
+    assert.ok(
+      binding !== undefined,
+      "agents.retrieval is 'ai-search' but wrangler.jsonc declares no AI_SEARCH binding — " +
+        'every search on this deployment would silently serve the lexical index instead',
+    );
+    assert.equal(
+      binding,
+      instance,
+      'the AI Search instance is named twice and the two names disagree: ' +
+        `wrangler.jsonc binds "${binding}", agents.aiSearchInstance says "${instance}". ` +
+        'scripts/index-sync.mjs uploads the corpus to the second while the Worker ' +
+        'queries the first, so the index that gets built is not the index that gets read',
+    );
+  });
+});

--- a/test/components.test.mjs
+++ b/test/components.test.mjs
@@ -264,6 +264,17 @@ describe('source guards', () => {
      */
     if (!existsSync(distDir)) return;
 
+    /* Stripped from every target before it is looked up, because the two sides
+       disagree about it on a subpath deployment. `_redirects` is evaluated by
+       Cloudflare against the incoming request, so its paths carry `basePath`,
+       while `dist/` is written without it — the same asymmetry the Worker
+       handles by stripping the prefix before `ASSETS.fetch()`. Without this the
+       guard would report every rule of a site served under a subpath as broken,
+       which is worse than not having it: a fork's first CI run would fail on
+       correct configuration. */
+    const basePath = (readFileSync(path.join(SRC, 'docs.config.ts'), 'utf8')
+      .match(/export const basePath = '([^']*)'/) ?? [, ''])[1];
+
     const rules = readFileSync(path.join(ROOT, 'public', '_redirects'), 'utf8')
       .split('\n')
       .map(line => line.trim())
@@ -275,7 +286,9 @@ describe('source guards', () => {
        target is a directory holding index.html, while /sitemap.xml and friends
        are files. Accept either, and let a bare extension answer for itself. */
     const built = target => {
-      const relative = target.replace(/^\//, '');
+      const withoutBase =
+        basePath && target.startsWith(`${basePath}/`) ? target.slice(basePath.length) : target;
+      const relative = withoutBase.replace(/^\//, '');
       if (!relative) return true;
       return (
         existsSync(path.join(distDir, relative, 'index.html')) ||

--- a/test/components.test.mjs
+++ b/test/components.test.mjs
@@ -246,6 +246,57 @@ describe('the site-wide banner', () => {
  * made once, is invisible in review, and is one grep away from never recurring.
  */
 describe('source guards', () => {
+  test('every _redirects rule points at something the build produced', () => {
+    /*
+     * The companion to the `_headers` guard below, for the file whose failure is
+     * louder and no more visible from here.
+     *
+     * `_redirects` exists so that a restructure does not break a published URL.
+     * A rule whose target has since been renamed keeps redirecting — to a 404,
+     * which is strictly worse than the 404 the rule was added to prevent: the
+     * old URL now reports a permanent move to a page that is not there, and
+     * `curl` on the old path returns 301 and looks healthy. Nothing in the build
+     * output, and nothing in Cloudflare, mentions it.
+     *
+     * Only local targets are judged. An off-site destination cannot be checked
+     * against `dist/`, and a rule with a `:placeholder` or a `*` in it is a
+     * pattern rather than a path — both are skipped rather than guessed at.
+     */
+    if (!existsSync(distDir)) return;
+
+    const rules = readFileSync(path.join(ROOT, 'public', '_redirects'), 'utf8')
+      .split('\n')
+      .map(line => line.trim())
+      .filter(line => line && !line.startsWith('#'))
+      .map(line => line.split(/\s+/))
+      .filter(([from, to]) => from && to);
+
+    /* Astro builds in directory format with `trailingSlash: 'never'`, so a page
+       target is a directory holding index.html, while /sitemap.xml and friends
+       are files. Accept either, and let a bare extension answer for itself. */
+    const built = target => {
+      const relative = target.replace(/^\//, '');
+      if (!relative) return true;
+      return (
+        existsSync(path.join(distDir, relative, 'index.html')) ||
+        existsSync(path.join(distDir, `${relative}.html`)) ||
+        existsSync(path.join(distDir, relative))
+      );
+    };
+
+    const broken = rules
+      .filter(([, to]) => to.startsWith('/') && !/[:*]/.test(to))
+      .filter(([, to]) => !built(to))
+      .map(([from, to]) => `${from} -> ${to}`);
+
+    assert.deepEqual(
+      broken,
+      [],
+      'these _redirects rules send a published URL to a path this build does not ' +
+        'contain, so the old link answers 301 and then 404',
+    );
+  });
+
   test('every _headers rule matches something the build produced', () => {
     /*
      * A `_headers` rule that matches nothing is invisible. Cloudflare does not


### PR DESCRIPTION
Three small guards, each for a disagreement that today produces a site
which looks entirely healthy.

wrangler.jsonc already says the AI Search `instance_name` "has to match
`agents.aiSearchInstance` in src/docs.config.ts exactly", and nothing
checked it. The disagreement has no symptom to find it by: `retrieve()`
catches a missing or misnamed binding and serves the lexical index
instead — deliberately, so a misconfiguration degrades rather than
500s — which leaves a deployment whose semantic index was never bound
answering every search, plausibly, forever, with the floor
implementation. index-sync.mjs would meanwhile upload the corpus to the
name the config gives, so the index that gets built is not the index
that gets read. The `search-timing` log does name the backend on every
request, so the evidence exists; nothing brings anyone to look at it.
Asserted in one direction only, so a fork choosing 'lexical' does not
fail CI over a line it has no reason to touch.

`_redirects` had no guard at all, which is worse for it than for
`_headers`: a rule whose target was later renamed keeps answering 301,
to a 404. That is strictly worse than the 404 the rule was added to
prevent, and `curl` on the old path reports a permanent move and looks
correct. Local targets only — an off-site destination cannot be checked
against dist/, and a rule holding `:placeholder` or `*` is a pattern
rather than a path.

Finally, two redirects for sitemap names crawlers guess before reading
robots.txt. /sitemap_index.xml is the convention of the largest
WordPress SEO plugins and was requested repeatedly on a sibling site by
Googlebot, bingbot and meta-externalagent. Answering the guess costs one
301; the alternative is restructuring a 22-URL sitemap around an index
it has no need for. Only the two spellings actually observed are here —
a longer list would be guesses about guesses.

Verified against a real Worker: both new paths 301 in one hop to a 200,
and the existing rule still resolves. Each guard was mutation-tested —
a divergent instance_name, a deleted binding, and a renamed redirect
target each fail it, while 'lexical' skips it and external targets and
patterns are ignored.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
Signed-off-by: DuvInc <206617480+DuvInc@users.noreply.github.com>
