### PR TITLE
Give the WebMCP bridge its base path, and turn it on

### DIFF
--- a/content/agents/mcp.mdx
+++ b/content/agents/mcp.mdx
@@ -26,8 +26,17 @@ chunk granularity, which no per-page metadata field could ever express.
 
 ## WebMCP
 
-Cloudflare's hosted bridge is the recommended route when the domain is a
-Cloudflare zone. In the dashboard, go to **Agent Readiness → Labs → Enable
+There are two ways to register these tools with an in-browser agent, and
+duvlify.dev runs the first.
+
+Set `agents.webmcpBridge` to `'on'` and this repository registers them
+itself, from
+[`src/components/WebMcpBridge.astro`](https://github.com/DuvInc/duvlify/blob/main/src/components/WebMcpBridge.astro).
+This is the default here, and it is the **only** option for a deployment
+under a subpath or on a domain that is not a Cloudflare zone.
+
+The alternative is Cloudflare's hosted bridge, which costs nothing to
+maintain. In the dashboard, go to **Agent Readiness → Labs → Enable
 WebMCP**, then under *Tool packs* check **Site MCP server** only.
 
 The interface says "Leave every pack unchecked to use the default set". The
@@ -41,11 +50,18 @@ generic documentation MCP. It finds this site's server at `<origin>/mcp`,
 which is why the MCP endpoint lives on the site's Worker rather than on one
 of Cloudflare's own.
 
+It finds that server by convention, not configuration: the pack requests
+`tools/list` from `<origin>/mcp` and relays whatever comes back, so nothing
+about your tools is ever declared to Cloudflare.
+
+That origin is hard-coded, which is the catch. A site served from `/docs`
+has its MCP server at `<origin>/docs/mcp`, where the pack never looks, so it
+registers no tools of yours at all. Subpath deployments must use the
+repository's own bridge. See [Deploying](/guides/deployment).
+
 Where there is no zone, such as a `workers.dev` deployment or a fork without
-a Cloudflare domain, that dashboard screen does not exist. In that case, set
-`agents.webmcpBridge` to `'on'`, and this repository registers the tools
-itself from
-[`src/components/WebMcpBridge.astro`](https://github.com/DuvInc/duvlify/blob/main/src/components/WebMcpBridge.astro).
+a Cloudflare domain, that dashboard screen does not exist either.
+
 Never run both methods together, or the tools would be registered twice.
 
 The browser API was renamed from `navigator.modelContext` to
@@ -78,6 +94,21 @@ The test suite knew about them; the bridge did not, because the suite built
 its own request instead of using the shipped one. This is the lesson worth
 keeping: a test that reimplements the thing it is testing stays green
 through the bug.
+
+A third defect outlived both, and it is the reason the two endpoints take a
+prefix argument rather than being written bare. `/mcp/tools` and `/mcp` were
+absolute paths. At the empty `basePath` this repository ships they are
+correct, so duvlify.dev worked — but under a subpath deployment they resolve
+against the origin root, where nothing answers. A fork serving its
+documentation from `/docs` registered zero tools while looking entirely
+healthy, because `loadTools` returns an empty list when the route is
+unreachable and said nothing about it. It now warns, and the component
+passes `site.basePath` to both calls.
+
+This one could not be spelled `withBase(…)` like every other framework-level
+path. `src/lib/webmcp.ts` imports nothing on purpose — that is what lets a
+test load it under Node's type stripping — so the base has to arrive as an
+argument, and `test/publication.test.mjs` asserts the component supplies it.
 
 The handful of lines left in the component are still uncovered by tests.
 There is no `modelContext` object in Node, and stubbing one would only prove

--- a/content/agents/mcp.mdx
+++ b/content/agents/mcp.mdx
@@ -99,11 +99,13 @@ A third defect outlived both, and it is the reason the two endpoints take a
 prefix argument rather than being written bare. `/mcp/tools` and `/mcp` were
 absolute paths. At the empty `basePath` this repository ships they are
 correct, so duvlify.dev worked — but under a subpath deployment they resolve
-against the origin root, where nothing answers. A fork serving its
-documentation from `/docs` registered zero tools while looking entirely
-healthy, because `loadTools` returns an empty list when the route is
-unreachable and said nothing about it. It now warns, and the component
-passes `site.basePath` to both calls.
+against the origin root, where nothing answers, and any subpath deployment
+of this engine would have registered no tools at all.
+
+Nothing would have said so, either: `loadTools` returns an empty list when
+the route is unreachable, and the component swallowed the rest in a bare
+`catch`, so a broken bridge and a browser without an agent looked identical.
+It now warns, and the component passes `site.basePath` to both calls.
 
 This one could not be spelled `withBase(…)` like every other framework-level
 path. `src/lib/webmcp.ts` imports nothing on purpose — that is what lets a

--- a/content/reference/configuration.mdx
+++ b/content/reference/configuration.mdx
@@ -187,7 +187,7 @@ export const agents = {
   defaultLimit: 8,
   maxLimit: 25,
   feedback: { webhook: undefined, fields: [ … ], context: [ … ] },
-  webmcpBridge: 'off',      // 'on' where there is no Cloudflare zone
+  webmcpBridge: 'on',       // 'off' delegates to Cloudflare's hosted bridge
   rateLimit: { search: 30, read: 90, write: 2 },
 };
 ```

--- a/handbook/agents/mcp.md
+++ b/handbook/agents/mcp.md
@@ -2,7 +2,7 @@
 title: "The manifest, WebMCP and limits"
 description: "The page outline agents read for line offsets, the in-browser WebMCP bridge and when to run it yourself, the rate limits, and how the surfaces are tested."
 canonical: "https://duvlify.dev/agents/mcp"
-updated: "2026-08-18"
+updated: "2026-08-28"
 ---
 
 # The manifest, WebMCP and limits
@@ -101,11 +101,13 @@ A third defect outlived both, and it is the reason the two endpoints take a
 prefix argument rather than being written bare. `/mcp/tools` and `/mcp` were
 absolute paths. At the empty `basePath` this repository ships they are
 correct, so duvlify.dev worked — but under a subpath deployment they resolve
-against the origin root, where nothing answers. A fork serving its
-documentation from `/docs` registered zero tools while looking entirely
-healthy, because `loadTools` returns an empty list when the route is
-unreachable and said nothing about it. It now warns, and the component
-passes `site.basePath` to both calls.
+against the origin root, where nothing answers, and any subpath deployment
+of this engine would have registered no tools at all.
+
+Nothing would have said so, either: `loadTools` returns an empty list when
+the route is unreachable, and the component swallowed the rest in a bare
+`catch`, so a broken bridge and a browser without an agent looked identical.
+It now warns, and the component passes `site.basePath` to both calls.
 
 This one could not be spelled `withBase(…)` like every other framework-level
 path. `src/lib/webmcp.ts` imports nothing on purpose — that is what lets a

--- a/handbook/agents/mcp.md
+++ b/handbook/agents/mcp.md
@@ -28,8 +28,17 @@ chunk granularity, which no per-page metadata field could ever express.
 
 ## WebMCP
 
-Cloudflare's hosted bridge is the recommended route when the domain is a
-Cloudflare zone. In the dashboard, go to **Agent Readiness → Labs → Enable
+There are two ways to register these tools with an in-browser agent, and
+duvlify.dev runs the first.
+
+Set `agents.webmcpBridge` to `'on'` and this repository registers them
+itself, from
+[`src/components/WebMcpBridge.astro`](https://github.com/DuvInc/duvlify/blob/main/src/components/WebMcpBridge.astro).
+This is the default here, and it is the **only** option for a deployment
+under a subpath or on a domain that is not a Cloudflare zone.
+
+The alternative is Cloudflare's hosted bridge, which costs nothing to
+maintain. In the dashboard, go to **Agent Readiness → Labs → Enable
 WebMCP**, then under _Tool packs_ check **Site MCP server** only.
 
 The interface says "Leave every pack unchecked to use the default set". The
@@ -43,11 +52,18 @@ generic documentation MCP. It finds this site's server at `<origin>/mcp`,
 which is why the MCP endpoint lives on the site's Worker rather than on one
 of Cloudflare's own.
 
+It finds that server by convention, not configuration: the pack requests
+`tools/list` from `<origin>/mcp` and relays whatever comes back, so nothing
+about your tools is ever declared to Cloudflare.
+
+That origin is hard-coded, which is the catch. A site served from `/docs`
+has its MCP server at `<origin>/docs/mcp`, where the pack never looks, so it
+registers no tools of yours at all. Subpath deployments must use the
+repository's own bridge. See [Deploying](/guides/deployment).
+
 Where there is no zone, such as a `workers.dev` deployment or a fork without
-a Cloudflare domain, that dashboard screen does not exist. In that case, set
-`agents.webmcpBridge` to `'on'`, and this repository registers the tools
-itself from
-[`src/components/WebMcpBridge.astro`](https://github.com/DuvInc/duvlify/blob/main/src/components/WebMcpBridge.astro).
+a Cloudflare domain, that dashboard screen does not exist either.
+
 Never run both methods together, or the tools would be registered twice.
 
 The browser API was renamed from `navigator.modelContext` to
@@ -80,6 +96,21 @@ The test suite knew about them; the bridge did not, because the suite built
 its own request instead of using the shipped one. This is the lesson worth
 keeping: a test that reimplements the thing it is testing stays green
 through the bug.
+
+A third defect outlived both, and it is the reason the two endpoints take a
+prefix argument rather than being written bare. `/mcp/tools` and `/mcp` were
+absolute paths. At the empty `basePath` this repository ships they are
+correct, so duvlify.dev worked — but under a subpath deployment they resolve
+against the origin root, where nothing answers. A fork serving its
+documentation from `/docs` registered zero tools while looking entirely
+healthy, because `loadTools` returns an empty list when the route is
+unreachable and said nothing about it. It now warns, and the component
+passes `site.basePath` to both calls.
+
+This one could not be spelled `withBase(…)` like every other framework-level
+path. `src/lib/webmcp.ts` imports nothing on purpose — that is what lets a
+test load it under Node's type stripping — so the base has to arrive as an
+argument, and `test/publication.test.mjs` asserts the component supplies it.
 
 The handful of lines left in the component are still uncovered by tests.
 There is no `modelContext` object in Node, and stubbing one would only prove

--- a/handbook/reference/configuration.md
+++ b/handbook/reference/configuration.md
@@ -2,7 +2,7 @@
 title: "Configuration"
 description: "Every setting lives in src/docs.config.ts, in five exports for identity, search, theme, navigation, and agent surfaces."
 canonical: "https://duvlify.dev/reference/configuration"
-updated: "2026-08-18"
+updated: "2026-08-28"
 ---
 
 # Configuration

--- a/handbook/reference/configuration.md
+++ b/handbook/reference/configuration.md
@@ -190,7 +190,7 @@ export const agents = {
   defaultLimit: 8,
   maxLimit: 25,
   feedback: { webhook: undefined, fields: [ … ], context: [ … ] },
-  webmcpBridge: 'off',      // 'on' where there is no Cloudflare zone
+  webmcpBridge: 'on',       // 'off' delegates to Cloudflare's hosted bridge
   rateLimit: { search: 30, read: 90, write: 2 },
 };
 ```

--- a/src/components/WebMcpBridge.astro
+++ b/src/components/WebMcpBridge.astro
@@ -26,6 +26,7 @@
 ---
 
 <script>
+  import { site } from '../docs.config';
   import { callTool, loadTools } from '../lib/webmcp';
 
   interface ModelContext {
@@ -45,10 +46,12 @@
   if (target) {
     void (async () => {
       try {
-        for (const tool of await loadTools()) {
+        /* Both calls need site.basePath: the endpoints are same-origin, but
+           a subpath deployment does not serve them at the origin root. */
+        for (const tool of await loadTools(site.basePath)) {
           target.registerTool({
             ...tool,
-            execute: args => callTool(tool.name, args),
+            execute: args => callTool(tool.name, args, site.basePath),
           });
         }
       } catch {

--- a/src/docs.config.ts
+++ b/src/docs.config.ts
@@ -515,15 +515,23 @@ export const agents = {
   /**
    * The in-browser bridge that republishes these tools to a WebMCP agent.
    *
-   *   'off'  Cloudflare's hosted bridge handles it — the "Site MCP server" pack
-   *          under Agent Readiness → Labs. Recommended wherever the domain is a
-   *          Cloudflare zone, because it costs nothing to maintain.
-   *   'on'   this repository registers the tools itself. For a deployment with
-   *          no zone, where that dashboard toggle does not exist.
+   *   'on'   this repository registers the tools itself, from
+   *          `src/components/WebMcpBridge.astro`. Required for a subpath
+   *          deployment and for any domain that is not a Cloudflare zone.
+   *   'off'  Cloudflare's hosted bridge handles it instead — the "Site MCP
+   *          server" pack under Agent Readiness → Labs. Costs nothing to
+   *          maintain, but only works when the documentation is served from the
+   *          origin root: that pack looks for the site's MCP server at `/mcp`
+   *          and the path is hard-coded, so a site under `/docs` gets a bridge
+   *          that finds nothing.
    *
    * Never both: the tools would be registered twice.
+   *
+   * duvlify.dev runs `'on'`, though its domain is a zone and either would work.
+   * The bridge is part of what this project demonstrates, so the site runs the
+   * code it ships rather than a dashboard toggle a reader cannot inspect.
    */
-  webmcpBridge: 'off' as 'off' | 'on',
+  webmcpBridge: 'on' as 'off' | 'on',
 
   /**
    * Requests per minute per IP, per tool family. Enforced by the Workers rate

--- a/src/lib/webmcp.ts
+++ b/src/lib/webmcp.ts
@@ -19,14 +19,23 @@
  *      removed it.
  *
  * A third defect outlived both, for the same reason — no browser test — and was
- * found only by reading a fork's live HTML:
+ * found by comparing this bridge against a fork's deployed one:
  *
- *   3. `/mcp/tools` and `/mcp` were written as bare absolute paths. At the empty
- *      `basePath` this repository ships they are correct, so duvlify.dev worked;
- *      under a subpath deployment they resolve against the origin root, where
- *      nothing answers. A fork serving its documentation from `/docs` registered
- *      zero tools while looking perfectly healthy. Both now go through
- *      `withBase`, and `test/publication.test.mjs` guards them there.
+ *   3. `/mcp/tools` and `/mcp` were written as bare absolute paths, and nothing
+ *      supplied a prefix. At the empty `basePath` this repository ships they are
+ *      correct, so duvlify.dev worked and the defect stayed latent; any subpath
+ *      deployment of this engine would have resolved them against the origin
+ *      root, where nothing answers, and registered no tools at all. A fork
+ *      serving its documentation from `/docs` had already repaired it locally,
+ *      which is how the gap became visible here.
+ *
+ * Both paths now carry a caller-supplied prefix, which the component fills from
+ * `site.basePath`; `test/publication.test.mjs` guards that it does. That prefix
+ * is also why the two paths are still written bare below rather than wrapped in
+ * `withBase` like every other framework-level path. This module deliberately
+ * imports nothing — that is what lets a test load it under Node's type
+ * stripping, with no bundler — so it cannot reach `docs.config.ts`, where
+ * `withBase` lives. The base has to arrive as an argument.
  */
 
 /** A tool as published by `/mcp/tools`, in the shape `registerTool` expects. */

--- a/src/lib/webmcp.ts
+++ b/src/lib/webmcp.ts
@@ -17,6 +17,16 @@
  *   2. Given that header, the SDK answers in SSE. `response.json()` throws on
  *      it. Fixing only the first defect would have moved the failure, not
  *      removed it.
+ *
+ * A third defect outlived both, for the same reason — no browser test — and was
+ * found only by reading a fork's live HTML:
+ *
+ *   3. `/mcp/tools` and `/mcp` were written as bare absolute paths. At the empty
+ *      `basePath` this repository ships they are correct, so duvlify.dev worked;
+ *      under a subpath deployment they resolve against the origin root, where
+ *      nothing answers. A fork serving its documentation from `/docs` registered
+ *      zero tools while looking perfectly healthy. Both now go through
+ *      `withBase`, and `test/publication.test.mjs` guards them there.
  */
 
 /** A tool as published by `/mcp/tools`, in the shape `registerTool` expects. */
@@ -58,10 +68,25 @@ export async function readRpcResponse(response: Response): Promise<unknown> {
   return JSON.parse(payloads[payloads.length - 1]);
 }
 
-/** The tool descriptors this site publishes, or none if the route is unreachable. */
-export async function loadTools(origin = ''): Promise<ToolDescriptor[]> {
-  const response = await fetch(`${origin}/mcp/tools`, { headers: { Accept: 'application/json' } });
-  if (!response.ok) return [];
+/**
+ * The tool descriptors this site publishes, or none if the route is unreachable.
+ *
+ * `prefix` is everything that precedes `/mcp`: `site.basePath` in the browser,
+ * so a subpath deployment reaches its own endpoint, and a whole origin in the
+ * tests, which point this at a Worker running on a port.
+ *
+ * The empty list is deliberate — a documentation page still has to render when
+ * its own MCP endpoint is down — but it used to be returned in complete silence,
+ * which is how defect 3 above survived a full deployment. The warning costs
+ * nothing in the browser that has no agent, because nothing calls this there.
+ */
+export async function loadTools(prefix = ''): Promise<ToolDescriptor[]> {
+  const url = `${prefix}/mcp/tools`;
+  const response = await fetch(url, { headers: { Accept: 'application/json' } });
+  if (!response.ok) {
+    console.warn(`WebMCP bridge: ${url} answered ${response.status}, so no tools were registered.`);
+    return [];
+  }
   const body = (await response.json()) as { tools?: ToolDescriptor[] };
   return body.tools ?? [];
 }
@@ -77,9 +102,9 @@ export async function loadTools(origin = ''): Promise<ToolDescriptor[]> {
 export async function callTool(
   name: string,
   args: Record<string, unknown>,
-  origin = '',
+  prefix = '',
 ): Promise<string> {
-  const response = await fetch(`${origin}/mcp`, {
+  const response = await fetch(`${prefix}/mcp`, {
     method: 'POST',
     headers: { 'Content-Type': 'application/json', Accept: MCP_ACCEPT },
     body: JSON.stringify({ jsonrpc: '2.0', id: 1, method: 'tools/call', params: { name, arguments: args } }),

--- a/test/publication.test.mjs
+++ b/test/publication.test.mjs
@@ -572,6 +572,28 @@ describe('framework-level links go through withBase', () => {
     });
   }
 
+  /* The WebMCP bridge is the one case that cannot be spelled withBase(…).
+     `src/lib/webmcp.ts` imports nothing on purpose — that is what lets a test
+     load it under Node's type stripping — so it takes the base as an argument
+     and the component supplies it. Both call sites need it: the endpoints were
+     bare absolute paths for longer than anything else here, because the bridge
+     runs only in a browser with the WebMCP API and no test has one. A fork
+     deployed under /docs registered zero tools, silently, until someone read
+     its live HTML. */
+  test('src/components/WebMcpBridge.astro passes the base path to the bridge', () => {
+    const source = readFileSync(path.join(ROOT, 'src', 'components', 'WebMcpBridge.astro'), 'utf8');
+    assert.match(
+      source,
+      /loadTools\(\s*site\.basePath\s*\)/,
+      'loadTools() is called without site.basePath, so a subpath deployment registers no tools',
+    );
+    assert.match(
+      source,
+      /callTool\(\s*tool\.name\s*,\s*args\s*,\s*site\.basePath\s*\)/,
+      'callTool() is called without site.basePath, so a subpath deployment cannot invoke a tool',
+    );
+  });
+
   test('src/lib/structured-data.ts wraps the organisation logo', () => {
     const source = readFileSync(path.join(ROOT, 'src', 'lib', 'structured-data.ts'), 'utf8');
     assert.match(


### PR DESCRIPTION
## The bug

The bridge fetched `/mcp/tools` and posted to `/mcp` as bare absolute paths, and nothing supplied a prefix. At the empty `basePath` this repository ships those are correct, so duvlify.dev works and the defect stayed **latent** — but any subpath deployment of this engine would have resolved them against the origin root, where nothing answers, and registered no tools at all.

Nothing would have reported it, either. `loadTools` returns an empty list on an unreachable route and the component swallowed the rest in a bare `catch`, so a broken bridge and a browser without an agent looked identical.

It surfaced by comparing this bridge against a fork's deployed one: the fork serves its documentation from `/docs` and had already repaired this locally, passing `site.basePath` to both calls. Upstream never had it.

## The fix

This is the one framework-level path that cannot be spelled `withBase(…)`. `src/lib/webmcp.ts` imports nothing on purpose — that is what lets a test load it under Node's type stripping, with no bundler — so it cannot reach `docs.config.ts`.

Both functions take the prefix as an argument instead, and the component fills it from `site.basePath`. `test/publication.test.mjs` asserts that it does, which is the invariant `withBase` guards everywhere else. `loadTools` now warns instead of failing silently.

## Also: the bridge is on

`agents.webmcpBridge` flips to `'on'`. duvlify.dev is a Cloudflare zone, so either route would work, but the bridge is part of what this project demonstrates — the site should run the code it ships rather than a dashboard toggle a reader cannot inspect.

Documented alongside: Cloudflare's hosted pack discovers a site's MCP server at a **hard-coded** `<origin>/mcp`, so a subpath deployment must use this bridge. `guides/deployment` already said so; `agents/mcp` now agrees, and records how the pack discovers tools at all — `tools/list`, by convention, with nothing declared to Cloudflare.

## Verification

- Full suite green — 101 pass, 2 skips (the documented ones).
- The new guard was mutation-tested: it fails when `site.basePath` is dropped from either call site.
- A build under `basePath: '/docs'` emits a bridge that reaches `/docs/mcp/tools`.
- **In a real browser**, against a local Worker with a stubbed `modelContext`: the bridge registers `search`, `fetch` and `list_pages`, and `search.execute()` returns real results. That path had never been exercised in a browser before.

The second commit corrects a claim in the first — it asserted the fork was broken, which was an inference from this repository's component rather than an observation of the fork's, and it had reached `content/agents/mcp.mdx`.